### PR TITLE
fixed float to int

### DIFF
--- a/qwiic_pca9685.py
+++ b/qwiic_pca9685.py
@@ -1292,7 +1292,7 @@ class QwiicPCA9685(object):
 
 		
 		# Calculate prescale value
-		pwmPreScale = round(float(osc_clock/(4096*frequency))) - 1
+		pwmPreScale = int(round(float(osc_clock/(4096*frequency)))) - 1
 		
 		# Writes 1 to SLEEP bit in MODE1 register.
 		self.set_sleep_bit(1)


### PR DESCRIPTION
my raspi4 with the raspbian buster, python 2.7 produced the following symptoms:

>>> import pi_servo_hat
>>> mySensor = pi_servo_hat.PiServoHat(debug=1)
PWM Frequency: 50
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/pi_servo_hat.py", line 169, in __init__
    self.set_pwm_frequency(_DEFAULT_SERVO_FREQUENCY)
  File "/usr/local/lib/python2.7/dist-packages/pi_servo_hat.py", line 249, in set_pwm_frequency
    if self.PCA9685.set_pre_scale(frequency) == True:
  File "/usr/local/lib/python2.7/dist-packages/qwiic_pca9685.py", line 1301, in set_pre_scale
    self._i2c.writeByte(self.address, PRE_SCALE, pwmPreScale)	
  File "/usr/local/lib/python2.7/dist-packages/qwiic_i2c/linux_i2c.py", line 226, in writeByte
    return self.i2cbus.write_byte_data(address, commandCode, value)
  File "/usr/local/lib/python2.7/dist-packages/smbus2/smbus2.py", line 433, in write_byte_data
    msg.data.contents.byte = value
TypeError: int expected instead of float